### PR TITLE
Modernize project build

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,59 +1,40 @@
 # Build
-1. Clone repo
-```
+## 1. Clone repo
+```sh
 git clone https://github.com/smile4u/bzenet bzenet
 cd bzenet
 ```
-2. Download latest enet lib and unpack it into `enet/` dir.
-3. Apply patches from `patches` folder.
-4. Install python modules: 
-    - Cython
-    - setuptool
-    - twine
+## 2. Download latest enet lib and unpack it into `enet/` dir.
+```sh
+git clone --branch v1.3.14 https://github.com/lsalzman/enet
+```
+## 3. Apply patches from `patches` folder.
+```sh
+git apply .\patches\01.patch_bze-14386.diff
+```
+## 4. Build package
 
-### Sources
-```
-python setup.py sdist
-twine upload dist/*
-```
+Requirements: python with pip and venv
 
-### Windows prebuild
-```
-python setup.py build --plat-name=win32 bdist_wheel
-python setup.py build --plat-name=win-amd64 bdist_wheel
-twine upload dist/*
-```
-Note: 
-- win32 build should be done with 32-bit Python installed
-- win-amd64 build should be done with 64-bit Python installed
-
-### Linux prebuild
-Run docker conrainer: (see https://github.com/pypa/manylinux)
-```
-docker run -it quay.io/pypa/manylinux2010_x86_64
-```
-or you can also specify a local dir with `bzenet` that will be available under docker:
-```
-docker run -it -v /path_to_local/bzenet:/bzenet quay.io/pypa/manylinux2010_x86_64
-```
-Under docker, install:
-```
-/opt/python/cp37-cp37m/bin/pip install Cython
-/opt/python/cp37-cp37m/bin/pip install twine
-```
-Under docker, run from cloned `bzenet` folder:
-```
-cd /bzenet
-/opt/python/cp37-cp37m/bin/python3.7 setup.py bdist_wheel
-auditwheel repair dist/*
-/opt/python/cp37-cp37m/bin/twine upload wheelhouse/*
+Prepare venv
+```sh
+python -m venv .venv
+.venv\Scripts\python.exe -m pip install setuptools cython twine build
 ```
 
-### Mac prebuild
-Sources package should be ok for osx.
+Build package
+```sh
+.venv\Scripts\python.exe -m build
+```
 
-Or pre-build it with:
+# Publish
+```sh
+.venv\Scripts\python.exe -m twine upload dist/*
 ```
-python setup.py bdist_wheel
-twine upload dist/*
+
+# Test
+```sh
+.venv\Scripts\python.exe -m pip install -e .
+.venv\Scripts\python.exe test_enet.py
 ```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bzenet"
+version = "0.1.6"
+description = "A python wrapper for the ENet library ver. 1.3.14"
+urls = { Homepage = "https://github.com/smile4u/bzenet" }
+maintainers = [
+    { name = "Sergey Zdanevich, BlitzTeam", email = "sergey.zdanevich@blitzteam.com" },
+]
+
+[tool.setuptools.packages.find]
+exclude = ["enet", "patches"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython"]
+requires = ["setuptools>58.1.0", "cython>=3.1.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "bzenet"
 version = "0.1.6"
+requires-python = ">=3.10"
 description = "A python wrapper for the ENet library ver. 1.3.14"
 urls = { Homepage = "https://github.com/smile4u/bzenet" }
 maintainers = [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-from setuptools import setup
-from setuptools import Extension
-from Cython.Distutils import build_ext
+from setuptools import setup, Extension
+from Cython.Build import cythonize
 
 import glob
 import sys
@@ -44,15 +43,4 @@ ext_modules = [
         define_macros=define_macros)
     ]
 
-setup(
-    name='bzenet',
-    version='0.1.5',
-    description='A python wrapper for the ENet library ver. 1.3.14',
-    url='https://github.com/smile4u/bzenet',
-    maintainer='Sergey Zdanevich, BlitzTeam',
-    maintainer_email='sergey.zdanevich@blitzteam.com',
-    cmdclass={'build_ext': build_ext},
-    ext_modules=ext_modules,
-    setup_requires=['Cython>=0,<1'],
-    install_requires=['Cython>=0,<1']
-)
+setup(ext_modules=cythonize(ext_modules))


### PR DESCRIPTION
Motivation: 
- `build_ext from Cython.Distutils` is deprecated and don't recomended to use
- Modern projects recomended to use pyproject.toml manifest